### PR TITLE
Refactor to use debug naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # autodebug
-npm.im/debug but automatic
+
+https://npm.im/debug but with automatic namespacing
+
 
 ## usage
+
 ```js
 var debug = require('autodebug')
 debug('hello')
 ```
 
 ## example
+
 ```
-  autodebug:test.js test +0ms
-  autodebug:test/test.js test in another file +0ms
+  autodebug:foo test +0ms
+  autodebug:foo:bar test in another file +0ms
 ```
 
 Based on the [`debug`](https://www.npmjs.com/package/debug) module you know and love,
@@ -20,19 +24,26 @@ boilerplate.
 
 ## api
 
-just require in in each module you want to debug from and call it with things you want to debug
+Just require `autodebug` in each module you want to debug from and call it
+with things you want to debug
 
-just like the original `debug` module, you can control which modules' debug output is shown with
-the `DEBUG` environment variable. See https://www.npmjs.com/package/debug#usage
+Just like the original `debug` module, you can control which modules' debug
+output is shown with the `DEBUG` environment variable.
+
+See https://www.npmjs.com/package/debug#usage
+
 
 ## installation
 
-    $ npm install autodebug
+```bash
+$ npm install autodebug
+```
 
 
 ## contributors
 
 - jden <jason@denizac.org>
+- tootallnate <n@n8.io>
 
 
 ## license

--- a/index.js
+++ b/index.js
@@ -16,16 +16,22 @@ function tryReadPackageJson(dir) {
 // so that next require call gets re-evaluated
 delete require.cache[__filename]
 
-dir = path.dirname(module.parent.filename))
+var filename = module.parent.filename
+if (!filename) {
+  throw new Error('`autodebug` module can not be required in the REPL!')
+}
+
+dir = path.dirname(filename)
 while (!tryReadPackageJson(dir)) {
   dir = path.dirname(dir)
 }
 
 if (!root) {
-  throw new Error('could not find package root for ' + module.parent.filename)
+  throw new Error('could not find package root for ' + filename)
 }
 
 var packageName = require(path.resolve(dir, 'package.json')).name
-var rel = path.relative(root, module.parent.filename).replace(/\\/g, '/')
+var rel = path.relative(root, filename).replace(/\.js$/, '').split(/[\/\\]/g)
+var name = packageName + ':' + rel.join(':')
 
 module.exports = debug(name)

--- a/index.js
+++ b/index.js
@@ -1,14 +1,23 @@
-var d = require('debug')
+var fs = require('fs')
+var path = require('path')
+var debug = require('debug')
 
-//remove self from cache
+var root, dir
+
+function tryReadPackageJson(dir) {
+  var ok = fs.existsSync(path.resolve(dir, 'package.json'))
+  if (ok) {
+    root = dir
+  }
+  return ok
+}
+
+// remove self from require cache,
+// so that next require call gets re-evaluated
 delete require.cache[__filename]
 
-var path = require('path')
-var fs = require('fs')
-
-var dir = path.dirname(module.parent.filename)
-var root
-while(!tryReadPackageJson(dir)) {
+dir = path.dirname(module.parent.filename))
+while (!tryReadPackageJson(dir)) {
   dir = path.dirname(dir)
 }
 
@@ -19,17 +28,4 @@ if (!root) {
 var packageName = require(path.resolve(dir, 'package.json')).name
 var rel = path.relative(root, module.parent.filename).replace(/\\/g, '/')
 
-function tryReadPackageJson(dir) {
-  var ok = fs.existsSync(path.resolve(dir, 'package.json'))
-  if (ok) {
-    root = dir
-  }
-  return ok
-}
-
-function debug () {
-  var args = arguments
-  d(packageName+':'+rel).apply(null, args)
-}
-
-module.exports = debug
+module.exports = debug(name)


### PR DESCRIPTION
Hey, cool module! I was having a similar idea and found yours. I hope that relying on the `require.cache` is reliable enough, especially in browser/emulation Node.js environments.

I did a minor cleanup, as well as a perhaps breaking change: the debug naming convention that I've grown accustomed to has been to replace the dir separators with colon `:` chars, and remove the file extension. So `project/foo/bar.js` has the namespace: `project:foo:bar` (old impl would have been `project:foo/bar.js`.

Not sure how you feel about that change but figured I'd throw it out there. Thanks for the module!
